### PR TITLE
Add topics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!IMPORTANT]
 > This module is experimental. The API is subject to change and may break at any time.
 
-Bluetooth LE transport shaped like [hyperswarm](https://github.com/holepunchto/hyperswarm). Nearby peers discover each other by advertising and scanning a topic-derived service UUID, negotiate a session over a single write+notify characteristic, and come out the other side as Noise-encrypted duplex streams. They are the same connections hyperswarm emits, so a BLE link feeds straight into corestore replication.
+Bluetooth LE transport shaped like [hyperswarm](https://github.com/holepunchto/hyperswarm). Nearby peers discover each other over a single fixed service UUID, negotiate the topics they share and a session in the handshake, and come out the other side as Noise-encrypted duplex streams. They are the same connections hyperswarm emits, so a BLE link feeds straight into corestore replication.
 
 Session data moves over one of two pipes, chosen up front: `l2cap` (a real L2CAP channel per session, faster and with native flow control) or `gatt` (a framed byte stream over the characteristic, works everywhere).
 
@@ -28,6 +28,7 @@ bt.on('connection', (conn) => {
 })
 
 await bt.start() // scan + advertise
+bt.join(otherTopic) // also keep links that share this topic
 
 await bt.suspend() // app backgrounds: radio io paused, start intent kept
 await bt.resume() // app foregrounds: radio io restored
@@ -40,8 +41,9 @@ await bt.resume() // app foregrounds: radio io restored
 Construct a new swarm. `opts` can include:
 
 - `keyPair`: the static Noise keypair used for identity and encryption, e.g. the hyperswarm keypair.
-- `topic`: the 32-byte topic the service UUID derives from. Only peers with the same topic discover each other.
-- `tag`: namespace for the service UUID. Defaults to `'ble-swarm'`.
+- `topic`: a 32-byte topic to join on construction.
+- `topics`: an array of 32-byte topics to join on construction.
+- `tag`: namespace for the fixed discovery UUID. Defaults to `'ble-swarm'`.
 - `shouldConnect(remotePublicKey)`: return `false` to refuse a peer before the handshake.
 - `maxOutbound`: concurrent outbound dials. Defaults to `4`.
 - `maxInbound`: concurrent inbound sessions. Defaults to `8`.
@@ -97,6 +99,18 @@ Pause all radio io for a transient host-lifecycle pause (app backgrounded), whil
 
 Restore the radio io paused by `suspend()`.
 
+#### `bt.join(topic)`
+
+Add a topic to the set. A link survives the handshake only if the two peers share at least one topic. `topic` must be a 32-byte Buffer. Takes effect on new links.
+
+#### `bt.leave(topic)`
+
+Remove a topic from the set. `topic` must be a 32-byte Buffer.
+
+#### `bt.topics()`
+
+The current set of joined topics, as an array of 32-byte Buffers.
+
 #### `bt.setOnline(online)`
 
 Hint from the host: while `true`, scanning duty-cycles lazily (BLE is a fallback); while `false`, it hunts aggressively (BLE is the only path).
@@ -108,6 +122,10 @@ A `{ state, peers }` snapshot, handy for reporting up to the host.
 #### `await bt.destroy()`
 
 Tear down for good, alias for `close()`. Stops the radio and releases the managers. The instance is single-use afterwards.
+
+## Topics
+
+Topics scope discovery, not what is shared. Every peer with the same `tag` advertises and scans one fixed service UUID, so discovery finds all nearby peers; the topic sets are then exchanged in the OPEN/HELLO handshake and a link is kept only if they overlap. A peer with no shared topic is refused on the control plane, before any L2CAP channel opens. Identity and encryption stay the Noise keypair, and replication over the link stays capability-gated, so two peers who share a topic but no data sync nothing.
 
 ## The two pipes
 
@@ -121,10 +139,10 @@ Either way, the characteristic still carries the OPEN/HELLO/CLOSE control frames
 
 ## Design notes
 
-- One data characteristic carries `[type:1][sessionId:8][payload]` frames. OPEN/HELLO payloads are `[key:32][flags:1]` followed by an optional PSM.
+- One data characteristic carries `[type:1][sessionId:8][payload]` frames. OPEN/HELLO payloads are `[key:32][flags:1]` followed by an optional PSM and topic list, the flag bits announcing which follow.
 - An l2cap central writes its 8-byte session id first so the server can match the channel to the session negotiated over GATT.
-- Both sides advertise and scan; a pair may link twice and both ends retire the same duplicate deterministically.
-- OPEN/HELLO carry the static public keys, so duplicate or unwanted peers are refused before any Noise work.
+- Both sides advertise and scan the one fixed UUID; a pair may link twice and both ends retire the same duplicate deterministically.
+- OPEN/HELLO carry the static public keys and the topic sets, so duplicate, unwanted, or non-overlapping peers are refused before any Noise work.
 - Liveness is keepalive/timeout based, since iOS emits no disconnect for a vanished peer.
 - Android centrals negotiate the MTU up (`requestMtu`) and size gatt chunks to it.
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const ReadyResource = require('ready-resource')
 const safetyCatch = require('safety-catch')
 const { isMac } = require('which-runtime')
+const b4a = require('b4a')
 
 const BLETransport = require('./lib/transport')
 
@@ -30,6 +31,9 @@ module.exports = class BluetoothSwarm extends ReadyResource {
     this._backend = opts.backend !== undefined ? opts.backend : backend
     this._online = opts.online === true
     this._gen = 0
+    this._topics = new Map()
+    const seed = opts.topics || (opts.topic !== undefined ? [opts.topic] : [])
+    for (const t of seed) this._topics.set(b4a.toString(t, 'hex'), t)
   }
 
   get supported() {
@@ -60,6 +64,22 @@ module.exports = class BluetoothSwarm extends ReadyResource {
 
   status() {
     return { state: this.state, peers: this.connections.size }
+  }
+
+  topics() {
+    return [...this._topics.values()]
+  }
+
+  join(topic) {
+    this._topics.set(b4a.toString(topic, 'hex'), topic)
+    if (this.transport) this.transport._setTopics(this.topics())
+    this.emit('update')
+  }
+
+  leave(topic) {
+    this._topics.delete(b4a.toString(topic, 'hex'))
+    if (this.transport) this.transport._setTopics(this.topics())
+    this.emit('update')
   }
 
   // One service per process: managers are reused across toggles (there is no
@@ -106,6 +126,7 @@ module.exports = class BluetoothSwarm extends ReadyResource {
       gen,
       backend: this._backend,
       online: this._online,
+      topics: this.topics(),
       onconnection: (conn) => this.emit('connection', conn)
     })
     transport.on('update', () => this.emit('update'))

--- a/lib/frames.js
+++ b/lib/frames.js
@@ -11,10 +11,13 @@ const SID_LEN = 8
 const HEADER = 1 + SID_LEN
 const KEY_LEN = 32
 
-// OPEN/HELLO payloads optionally extend past the key with a capability flag
-// byte (and, in HELLO, a 2-byte big-endian PSM): [key:32][flags:1][psm:2].
-// Old peers send bare keys (flags 0).
-const PIPE_L2CAP = 0x01
+// OPEN/HELLO payloads extend past the key with a flag byte whose bits announce
+// which optional fields follow, in order: [key:32][flags:1]([psm:2])([n:1][topic:32]xN).
+// flags 0 is a bare key.
+const PIPE_L2CAP = 0x01 // this peer offers an l2cap data pipe
+const HAS_PSM = 0x02 // a 2-byte big-endian PSM follows (HELLO)
+const HAS_TOPICS = 0x04 // a topic list follows: [count:1][topic:32] x count
+const TOPIC_LEN = 32
 
 const EMPTY = b4a.alloc(0)
 
@@ -37,19 +40,40 @@ function decodeFrame(buf) {
   }
 }
 
-function encodeKeyPayload(key, flags, psm) {
-  if (flags === 0) return key
-  if (psm === null) return b4a.concat([key, b4a.from([flags])])
-  return b4a.concat([key, b4a.from([flags, (psm >> 8) & 0xff, psm & 0xff])])
+function encodeKeyPayload(key, flags, psm, topics) {
+  const hasPsm = psm !== null && psm !== undefined
+  const hasTopics = topics && topics.length > 0
+  let f = flags
+  if (hasPsm) f |= HAS_PSM
+  if (hasTopics) f |= HAS_TOPICS
+  if (f === 0) return key
+  const parts = [key, b4a.from([f])]
+  if (hasPsm) parts.push(b4a.from([(psm >> 8) & 0xff, psm & 0xff]))
+  if (hasTopics) {
+    parts.push(b4a.from([topics.length]))
+    for (const t of topics) parts.push(t)
+  }
+  return b4a.concat(parts)
 }
 
 function decodeKeyPayload(payload) {
-  return {
-    key: payload.subarray(0, KEY_LEN),
-    flags: payload.byteLength > KEY_LEN ? payload[KEY_LEN] : 0,
-    psm:
-      payload.byteLength >= KEY_LEN + 3 ? (payload[KEY_LEN + 1] << 8) | payload[KEY_LEN + 2] : null
+  const key = payload.subarray(0, KEY_LEN)
+  const flags = payload.byteLength > KEY_LEN ? payload[KEY_LEN] : 0
+  let off = KEY_LEN + 1
+  let psm = null
+  if (flags & HAS_PSM) {
+    psm = (payload[off] << 8) | payload[off + 1]
+    off += 2
   }
+  const topics = []
+  if (flags & HAS_TOPICS) {
+    const n = payload[off++]
+    for (let i = 0; i < n; i++) {
+      topics.push(payload.subarray(off, off + TOPIC_LEN))
+      off += TOPIC_LEN
+    }
+  }
+  return { key, flags, psm, topics }
 }
 
 module.exports = {
@@ -61,6 +85,8 @@ module.exports = {
   HEADER,
   KEY_LEN,
   PIPE_L2CAP,
+  HAS_PSM,
+  HAS_TOPICS,
   encodeFrame,
   decodeFrame,
   encodeKeyPayload,

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -69,6 +69,8 @@ const STATE = {
   unknown: 'waiting'
 }
 
+const DISCOVERY = b4a.alloc(32)
+
 // Derive a stable 128-bit BLE service UUID from a topic. Only devices that
 // compute the same UUID ever discover each other.
 function toServiceUUID(topic, tag = 'ble-swarm') {
@@ -101,6 +103,7 @@ module.exports = class BLETransport extends ReadyResource {
     backend,
     keyPair,
     topic,
+    topics,
     onconnection,
     shouldConnect,
     tag = 'ble-swarm',
@@ -120,7 +123,8 @@ module.exports = class BLETransport extends ReadyResource {
     super()
     this.backend = backend
     this.keyPair = keyPair
-    this.serviceUUID = toServiceUUID(topic, tag)
+    this.serviceUUID = toServiceUUID(DISCOVERY, tag)
+    this._setTopics(topics || (topic !== undefined ? [topic] : []))
     this.onconnection = onconnection
     this.shouldConnect = shouldConnect || null
     this.maxOutbound = maxOutbound
@@ -250,6 +254,21 @@ module.exports = class BLETransport extends ReadyResource {
     return true
   }
 
+  _setTopics(bufs) {
+    this._topics = new Map()
+    for (const t of bufs) this._topics.set(b4a.toString(t, 'hex'), t)
+  }
+
+  _topicBufs() {
+    return [...this._topics.values()]
+  }
+
+  _sharedTopics(remote) {
+    const out = []
+    for (const t of remote) if (this._topics.has(b4a.toString(t, 'hex'))) out.push(t)
+    return out
+  }
+
   // Deterministic direction: the smaller static key is the one that initiates
   _weInitiate(remoteKey) {
     return b4a.compare(this.keyPair.publicKey, remoteKey) < 0
@@ -360,7 +379,7 @@ module.exports = class BLETransport extends ReadyResource {
     const s = this._sessions.get(f.id)
     if (f.type === TYPE_OPEN ? s : !s) return
     if (f.type === TYPE_OPEN) {
-      const { key, flags } = decodeKeyPayload(f.payload)
+      const { key, flags, topics } = decodeKeyPayload(f.payload)
       if (
         this._sessions.size >= this.maxInbound ||
         !this._accept(key) ||
@@ -368,6 +387,12 @@ module.exports = class BLETransport extends ReadyResource {
       ) {
         // wrong direction or unwanted peer — refuse so the dialer backs off
         this._log('server refused OPEN', f.id)
+        this._notifyClose(f.id)
+        return
+      }
+      const shared = this._sharedTopics(topics)
+      if (shared.length === 0) {
+        this._log('server refused OPEN, no shared topic', f.id)
         this._notifyClose(f.id)
         return
       }
@@ -391,11 +416,11 @@ module.exports = class BLETransport extends ReadyResource {
           this._notifyClose(f.id)
         }, PIPE_PENDING_TIMEOUT)
         if (session.pipeTimer.unref) session.pipeTimer.unref()
-        const hello = encodeKeyPayload(this.keyPair.publicKey, PIPE_L2CAP, this._l2cap.psm)
+        const hello = encodeKeyPayload(this.keyPair.publicKey, PIPE_L2CAP, this._l2cap.psm, shared)
         this._notifyHello(f.id, hello)
       } else {
         this._gatt.openServer(session)
-        this._notifyHello(f.id, this.keyPair.publicKey)
+        this._notifyHello(f.id, encodeKeyPayload(this.keyPair.publicKey, 0, null, shared))
       }
     } else if (f.type === TYPE_DATA) {
       if (!s.stream) {
@@ -700,7 +725,12 @@ module.exports = class BLETransport extends ReadyResource {
       if (peripheral._stream) peripheral._stream.maxPayload = this._gatt.getMaxPayload(peripheral)
     })
     this._log('central sent OPEN', peripheral.id)
-    const open = encodeKeyPayload(this.keyPair.publicKey, this._capabilities(), null)
+    const open = encodeKeyPayload(
+      this.keyPair.publicKey,
+      this._capabilities(),
+      null,
+      this._topicBufs()
+    )
     this._sendOpen(peripheral, id, open)
     try {
       peripheral.requestMtu(REQUEST_MTU) // no-op on Apple, mtuChanged on Android
@@ -716,9 +746,14 @@ module.exports = class BLETransport extends ReadyResource {
     if (!f || f.id !== sess.id) return
     if (f.type === TYPE_HELLO) {
       if (peripheral._stream || sess.upgrading) return
-      const { key, flags, psm } = decodeKeyPayload(f.payload)
+      const { key, flags, psm, topics } = decodeKeyPayload(f.payload)
       if (!this._accept(key)) {
         this._log('central refused HELLO', peripheral.id)
+        this._endCentral(peripheral, sess)
+        return
+      }
+      if (this._sharedTopics(topics).length === 0) {
+        this._log('central refused HELLO, no shared topic', peripheral.id)
         this._endCentral(peripheral, sess)
         return
       }

--- a/test/all.js
+++ b/test/all.js
@@ -2,7 +2,7 @@ const test = require('brittle')
 const b4a = require('b4a')
 const crypto = require('hypercore-crypto')
 
-const { createSwarm, once, until, link, linked, makeMockBluetooth } = require('./helpers')
+const { TOPIC, createSwarm, once, until, link, linked, makeMockBluetooth } = require('./helpers')
 
 // Tests drive the transport's real timers (dial intervals, scan cycles), so a
 // heavily loaded machine slips them. Declare a generous deadline so slowness
@@ -301,7 +301,7 @@ test('psm rotation waits for pending sessions instead of breaking them', async (
   // always accepts these OPENs
   const open = (id, fill) =>
     tr._onServerFrame(
-      encodeFrame(TYPE_OPEN, id, encodeKeyPayload(b4a.alloc(32, fill), PIPE_L2CAP, null))
+      encodeFrame(TYPE_OPEN, id, encodeKeyPayload(b4a.alloc(32, fill), PIPE_L2CAP, null, [TOPIC]))
     )
 
   // two inbound sessions, both still waiting for their l2cap channel
@@ -535,4 +535,118 @@ test('a crowd meshes within its link caps', async (t) => {
   // the dial machinery settles instead of storming
   await until(() => swarms.every((s) => !s.transport._isDialing()))
   t.pass('dialing settled')
+})
+
+test('topics: peers link only when their sets overlap', async (t) => {
+  const backend = makeMockBluetooth()
+  const X = crypto.hash(b4a.from('topic-x'))
+  const Y = crypto.hash(b4a.from('topic-y'))
+  const Z = crypto.hash(b4a.from('topic-z'))
+  const W = crypto.hash(b4a.from('topic-w'))
+
+  const a = createSwarm(t, backend, { topics: [X, Y] })
+  const b = createSwarm(t, backend, { topics: [Y, Z] }) // shares Y with a
+  const c = createSwarm(t, backend, { topics: [W] }) // shares nothing
+
+  await a.start()
+  await b.start()
+  await c.start()
+
+  await linked(a, b) // overlap on Y
+  await new Promise((resolve) => setTimeout(resolve, 200)) // let c try and be refused
+  t.is(c.connections.size, 0, 'no shared topic — c links nobody')
+  t.is(a.connections.size, 1, 'a links only b')
+})
+
+test('topics: join and leave manage the set and reach the live transport', async (t) => {
+  const backend = makeMockBluetooth()
+  const R = crypto.hash(b4a.from('room-r'))
+  const bt = createSwarm(t, backend, { topics: [] })
+  await bt.start()
+
+  t.is(bt.topics().length, 0, 'starts with no topics')
+  bt.join(R)
+  t.ok(
+    bt.topics().some((x) => b4a.equals(x, R)),
+    'join adds the topic'
+  )
+  t.is(bt.transport._topics.size, 1, 'the live transport sees the join')
+  bt.leave(R)
+  t.is(bt.topics().length, 0, 'leave removes it')
+  t.is(bt.transport._topics.size, 0, 'and the transport too')
+})
+
+test('topics: frame codec round-trips key, flags, psm and topics', (t) => {
+  const { PIPE_L2CAP, encodeKeyPayload, decodeKeyPayload } = require('../lib/frames')
+  const key = crypto.hash(b4a.from('key'))
+  const topics = [crypto.hash(b4a.from('t1')), crypto.hash(b4a.from('t2'))]
+
+  const hello = decodeKeyPayload(encodeKeyPayload(key, PIPE_L2CAP, 192, topics))
+  t.ok(b4a.equals(hello.key, key), 'key round-trips')
+  t.is(hello.psm, 192, 'psm round-trips')
+  t.is(hello.topics.length, 2, 'both topics decode')
+  t.ok(
+    b4a.equals(hello.topics[0], topics[0]) && b4a.equals(hello.topics[1], topics[1]),
+    'topic bytes intact and ordered'
+  )
+
+  const open = decodeKeyPayload(encodeKeyPayload(key, PIPE_L2CAP, null, topics))
+  t.is(open.psm, null, 'OPEN carries topics with no psm')
+  t.is(open.topics.length, 2, 'OPEN topics decode')
+
+  const bare = decodeKeyPayload(encodeKeyPayload(key, 0, null))
+  t.is(bare.flags, 0, 'bare key: no flags')
+  t.is(bare.psm, null, 'bare key: no psm')
+  t.is(bare.topics.length, 0, 'bare key: no topics')
+})
+
+test('topics: overlapping on several topics still yields one link', async (t) => {
+  const backend = makeMockBluetooth()
+  const P = crypto.hash(b4a.from('p'))
+  const Q = crypto.hash(b4a.from('q'))
+  const a = createSwarm(t, backend, { topics: [P, Q] })
+  const b = createSwarm(t, backend, { topics: [P, Q] })
+
+  await a.start()
+  await b.start()
+  await linked(a, b)
+  await new Promise((resolve) => setTimeout(resolve, 150))
+  t.is(a.connections.size, 1, 'two shared topics, still one link')
+  t.is(b.connections.size, 1)
+})
+
+test('topics: an empty set links nobody', async (t) => {
+  const backend = makeMockBluetooth()
+  const a = createSwarm(t, backend, { topics: [] })
+  const b = createSwarm(t, backend) // default TOPIC
+
+  await a.start()
+  await b.start()
+  await new Promise((resolve) => setTimeout(resolve, 300))
+  t.is(a.connections.size, 0, 'no topics — no overlap with anyone')
+  t.is(b.connections.size, 0)
+})
+
+test('topics: global links everyone; a room links only its members', async (t) => {
+  const backend = makeMockBluetooth()
+  const G = crypto.hash(b4a.from('global'))
+  const R = crypto.hash(b4a.from('room'))
+  const a = createSwarm(t, backend, { topics: [G] })
+  const b = createSwarm(t, backend, { topics: [G] })
+  const c = createSwarm(t, backend, { topics: [G, R] })
+  const d = createSwarm(t, backend, { topics: [R] })
+
+  await Promise.all([a, b, c, d].map((s) => s.start()))
+
+  // a,b,c share global; c,d share the room. Expected links: a-b, a-c, b-c, c-d.
+  await until(
+    () =>
+      a.connections.size === 2 &&
+      b.connections.size === 2 &&
+      c.connections.size === 3 &&
+      d.connections.size === 1
+  )
+  t.is(a.connections.size, 2, 'a (global) links b and c, not d')
+  t.is(c.connections.size, 3, 'c (global+room) links a, b and d')
+  t.is(d.connections.size, 1, 'd (room-only) links only c')
 })


### PR DESCRIPTION
Adds a hyperswarm-style `join(topic)` / `leave(topic)` / `topics()` API. Discovery stays a single scan, and the topics are matched in the handshake, so a link is kept only when two peers share one. Single-topic stays back-compatible.

Depends on #7, which needs to merge first.
