### PR TITLE
Cycle the l2cap listener on resume

### DIFF
--- a/lib/frames.js
+++ b/lib/frames.js
@@ -33,6 +33,14 @@ function encodeFrame(type, id, payload = EMPTY) {
   return out
 }
 
+function encodeCloseReason(reason) {
+  return reason ? b4a.from([reason]) : EMPTY
+}
+
+function decodeCloseReason(payload) {
+  return payload.byteLength > 0 ? payload[0] : 0
+}
+
 function decodeFrame(buf) {
   if (!buf || buf.byteLength < HEADER) return null
   return {
@@ -69,6 +77,8 @@ module.exports = {
   REASON_FINAL,
   encodeFrame,
   decodeFrame,
+  encodeCloseReason,
+  decodeCloseReason,
   encodeKeyPayload,
   decodeKeyPayload
 }

--- a/lib/frames.js
+++ b/lib/frames.js
@@ -16,6 +16,11 @@ const KEY_LEN = 32
 // Old peers send bare keys (flags 0).
 const PIPE_L2CAP = 0x01
 
+// Optional CLOSE payload byte. FINAL marks a refusal that can never succeed
+// (policy, pipe mismatch) so the dialer releases the physical link instead of
+// keeping it for a dial-back. Old peers send bare CLOSE and ignore the byte.
+const REASON_FINAL = 0x01
+
 const EMPTY = b4a.alloc(0)
 
 // The session id is a hex string end to end — the one canonical form (it is
@@ -61,6 +66,7 @@ module.exports = {
   HEADER,
   KEY_LEN,
   PIPE_L2CAP,
+  REASON_FINAL,
   encodeFrame,
   decodeFrame,
   encodeKeyPayload,

--- a/lib/l2cap.js
+++ b/lib/l2cap.js
@@ -166,7 +166,14 @@ module.exports = class L2CapPipe {
       }
       this.transport._log(`l2cap open psm=${psm}`, peripheral.id)
       const channel = await this._openChannel(peripheral, psm)
-      if (channel) this._centralChannels.set(peripheral.id, channel)
+      if (channel) {
+        this._centralChannels.set(peripheral.id, channel)
+        channel.on('close', () => {
+          if (this._centralChannels.get(peripheral.id) === channel) {
+            this._centralChannels.delete(peripheral.id)
+          }
+        })
+      }
       if (peripheral._session !== sess || this.transport._halted) {
         destroyChannel(channel)
         return

--- a/lib/l2cap.js
+++ b/lib/l2cap.js
@@ -97,6 +97,7 @@ module.exports = class L2CapPipe {
     this.transport = transport
     this.psm = null
     this._timeout = timeout ?? OPEN_TIMEOUT
+    this._centralChannels = new Map()
   }
 
   // ─── server (peripheral) side ─────────────────────────────────────────────
@@ -157,8 +158,15 @@ module.exports = class L2CapPipe {
     sess.upgrading = true
     try {
       const started = Date.now()
+      const stale = this._centralChannels.get(peripheral.id)
+      if (stale) {
+        this.transport._log('destroying stale l2cap channel', peripheral.id)
+        destroyChannel(stale)
+        this._centralChannels.delete(peripheral.id)
+      }
       this.transport._log(`l2cap open psm=${psm}`, peripheral.id)
       const channel = await this._openChannel(peripheral, psm)
+      if (channel) this._centralChannels.set(peripheral.id, channel)
       if (peripheral._session !== sess || this.transport._halted) {
         destroyChannel(channel)
         return

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -970,7 +970,8 @@ module.exports = class BLETransport extends ReadyResource {
     this._reapAllSessions()
     this._gatt.reset('suspended')
     // macOS only: a listener that lives through destroyed channels wedges the
-    // resumed manager. iOS tolerates no manager surgery — keep its listener.
+    // resumed manager. iOS broke on suspend-time surgery, so keep its listener
+    // here; resume cycles it instead.
     this._cyclePending = false // suspend tears the sessions down; resume republishes fresh
     if (isMac) this._l2cap.unpublish()
     this.state = 'off'

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -15,6 +15,7 @@ const {
   SID_LEN,
   KEY_LEN,
   PIPE_L2CAP,
+  REASON_FINAL,
   encodeFrame,
   decodeFrame,
   encodeKeyPayload,
@@ -285,9 +286,9 @@ module.exports = class BLETransport extends ReadyResource {
 
   // Decides a session's pipe from what both sides offered. Returns null when
   // no pipe suits both — links never silently ride the wrong pipe.
-  _pipeFor(remoteFlags, psm) {
-    if (this.pipe === 'gatt') return 'gatt'
-    return (remoteFlags & PIPE_L2CAP) !== 0 && psm !== null ? 'l2cap' : null
+  _pipeFor(remoteFlags) {
+    const l2cap = (remoteFlags & PIPE_L2CAP) !== 0
+    return l2cap === (this.pipe === 'l2cap') ? this.pipe : null
   }
 
   // ─── lifecycle ────────────────────────────────────────────────────────────
@@ -379,19 +380,20 @@ module.exports = class BLETransport extends ReadyResource {
     if (f.type === TYPE_OPEN ? s : !s) return
     if (f.type === TYPE_OPEN) {
       const { key, flags } = decodeKeyPayload(f.payload)
-      if (
-        this._sessions.size >= this.maxInbound ||
-        !this._accept(key) ||
-        !this._initiatorWins(key)
-      ) {
-        // wrong direction or unwanted peer — refuse so the dialer backs off
-        this._log('server refused OPEN', f.id)
-        this._notifyClose(f.id)
+      // final — the pair never links, the dialer releases the physical link
+      const name = this._pipeFor(flags)
+      if (!this._accept(key) || name === null) {
+        this._log('server refused OPEN, final', f.id)
+        this._notifyClose(f.id, REASON_FINAL)
         return
       }
-      const name = this._pipeFor(flags, this._l2cap.psm)
-      if (name === null) {
-        this._log('server refused OPEN, pipe mismatch', f.id)
+      // transient — the dialer keeps the link and redials
+      if (
+        (name === 'l2cap' && this._l2cap.psm === null) ||
+        this._sessions.size >= this.maxInbound ||
+        !this._initiatorWins(key)
+      ) {
+        this._log('server refused OPEN', f.id)
         this._notifyClose(f.id)
         return
       }
@@ -474,8 +476,9 @@ module.exports = class BLETransport extends ReadyResource {
     this._notifyClose(id)
   }
 
-  _notifyClose(id) {
-    return this._gatt.notify(encodeFrame(TYPE_CLOSE, id)).catch(safetyCatch)
+  _notifyClose(id, reason) {
+    const payload = reason ? b4a.from([reason]) : undefined
+    return this._gatt.notify(encodeFrame(TYPE_CLOSE, id, payload)).catch(safetyCatch)
   }
 
   _notifyHello(id, payload) {
@@ -749,8 +752,8 @@ module.exports = class BLETransport extends ReadyResource {
         this._endCentral(peripheral, sess, { keep: true })
         return
       }
-      const name = this._pipeFor(flags, psm)
-      if (name === null) {
+      const name = this._pipeFor(flags)
+      if (name === null || (name === 'l2cap' && psm === null)) {
         this._log('central refused HELLO, pipe mismatch', peripheral.id)
         this._endCentral(peripheral, sess)
         return
@@ -768,10 +771,9 @@ module.exports = class BLETransport extends ReadyResource {
         peripheral._session = null
         peripheral._stream.remoteEnd()
       } else {
-        // a pre-stream CLOSE is the peer's tie-break refusal: their channel
-        // rides this same physical link — a yielding central must never
-        // hang up (the dial cooldown already stops the redial)
-        this._endCentral(peripheral, null, { keep: true })
+        // keep on a plain refusal — the tie-break peer dials back over this link
+        const final = f.payload.byteLength > 0 && f.payload[0] === REASON_FINAL
+        this._endCentral(peripheral, null, { keep: !final })
       }
     }
   }

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -480,7 +480,9 @@ module.exports = class BLETransport extends ReadyResource {
   }
 
   _notifyClose(id, reason) {
-    return this._gatt.notify(encodeFrame(TYPE_CLOSE, id, encodeCloseReason(reason))).catch(safetyCatch)
+    return this._gatt
+      .notify(encodeFrame(TYPE_CLOSE, id, encodeCloseReason(reason)))
+      .catch(safetyCatch)
   }
 
   _notifyHello(id, payload) {

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -768,7 +768,10 @@ module.exports = class BLETransport extends ReadyResource {
         peripheral._session = null
         peripheral._stream.remoteEnd()
       } else {
-        this._endCentral(peripheral, null)
+        // a pre-stream CLOSE is the peer's tie-break refusal: their channel
+        // rides this same physical link — a yielding central must never
+        // hang up (the dial cooldown already stops the redial)
+        this._endCentral(peripheral, null, { keep: true })
       }
     }
   }
@@ -983,7 +986,8 @@ module.exports = class BLETransport extends ReadyResource {
     if (this.closing || this.closed) return
     this._advertising = false
     this._huntUntil = Date.now() + HUNT_WINDOW
-    if (this.pipe === 'l2cap') this._l2cap.publish()
+    // a dead session pins the old psm, so resume must republish on a fresh one
+    if (this.pipe === 'l2cap') this._l2cap.cycle()
     this._maybeAdvertise()
     this._startScan()
     const raw = this.central?.state ?? this.server?.state

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -18,6 +18,8 @@ const {
   REASON_FINAL,
   encodeFrame,
   decodeFrame,
+  encodeCloseReason,
+  decodeCloseReason,
   encodeKeyPayload,
   decodeKeyPayload
 } = require('./frames')
@@ -287,8 +289,9 @@ module.exports = class BLETransport extends ReadyResource {
   // Decides a session's pipe from what both sides offered. Returns null when
   // no pipe suits both — links never silently ride the wrong pipe.
   _pipeFor(remoteFlags) {
-    const l2cap = (remoteFlags & PIPE_L2CAP) !== 0
-    return l2cap === (this.pipe === 'l2cap') ? this.pipe : null
+    const remoteL2cap = (remoteFlags & PIPE_L2CAP) !== 0
+    const localL2cap = this.pipe === 'l2cap'
+    return remoteL2cap === localL2cap ? this.pipe : null
   }
 
   // ─── lifecycle ────────────────────────────────────────────────────────────
@@ -477,8 +480,7 @@ module.exports = class BLETransport extends ReadyResource {
   }
 
   _notifyClose(id, reason) {
-    const payload = reason ? b4a.from([reason]) : undefined
-    return this._gatt.notify(encodeFrame(TYPE_CLOSE, id, payload)).catch(safetyCatch)
+    return this._gatt.notify(encodeFrame(TYPE_CLOSE, id, encodeCloseReason(reason))).catch(safetyCatch)
   }
 
   _notifyHello(id, payload) {
@@ -772,7 +774,7 @@ module.exports = class BLETransport extends ReadyResource {
         peripheral._stream.remoteEnd()
       } else {
         // keep on a plain refusal — the tie-break peer dials back over this link
-        const final = f.payload.byteLength > 0 && f.payload[0] === REASON_FINAL
+        const final = decodeCloseReason(f.payload) === REASON_FINAL
         this._endCentral(peripheral, null, { keep: !final })
       }
     }

--- a/test/all.js
+++ b/test/all.js
@@ -100,6 +100,27 @@ test('resume cycles the l2cap listener — a dead session must not pin the psm',
   t.pass('relinked after suspend/resume on the new psm')
 })
 
+test('a final refusal releases the physical link', async (t) => {
+  const backend = makeMockBluetooth()
+  const a = createSwarm(t, backend, { pipe: 'l2cap' })
+  const b = createSwarm(t, backend, { pipe: 'gatt' })
+
+  await a.start()
+  await b.start()
+
+  // mismatched pipes refuse in both directions, neither side may hold the link
+  const released = (bt) => {
+    for (const d of bt.transport._devices.values()) {
+      if (d.coolUntil > Date.now() && !d.peripheral) return true
+    }
+    return false
+  }
+  await until(() => released(a) && released(b))
+
+  t.is(a.transport.peers.size, 0, 'no link formed')
+  t.pass('both sides dropped the physical link on the final refusal')
+})
+
 test('a closed l2cap channel leaves the central map', async (t) => {
   const backend = makeMockBluetooth()
   const a = createSwarm(t, backend, { pipe: 'l2cap' })

--- a/test/all.js
+++ b/test/all.js
@@ -100,6 +100,24 @@ test('resume cycles the l2cap listener — a dead session must not pin the psm',
   t.pass('relinked after suspend/resume on the new psm')
 })
 
+test('a closed l2cap channel leaves the central map', async (t) => {
+  const backend = makeMockBluetooth()
+  const a = createSwarm(t, backend, { pipe: 'l2cap' })
+  const b = createSwarm(t, backend, { pipe: 'l2cap' })
+
+  await a.start()
+  await b.start()
+  await linked(a, b)
+
+  const size = () =>
+    a.transport._l2cap._centralChannels.size + b.transport._l2cap._centralChannels.size
+  t.is(size(), 1, 'the dialing side holds its channel while linked')
+
+  await b.suspend()
+  await until(() => size() === 0)
+  t.pass('the map is empty once the channel closed')
+})
+
 test('resume respects stop: a disabled swarm stays off', async (t) => {
   const backend = makeMockBluetooth()
   const a = createSwarm(t, backend)

--- a/test/all.js
+++ b/test/all.js
@@ -77,6 +77,29 @@ test('suspend halts io and resume restores; both preserve the start intent', asy
   t.pass('relinked after suspend/resume')
 })
 
+test('resume cycles the l2cap listener — a dead session must not pin the psm', async (t) => {
+  const backend = makeMockBluetooth()
+  const a = createSwarm(t, backend, { pipe: 'l2cap' })
+  const b = createSwarm(t, backend, { pipe: 'l2cap' })
+
+  await a.start()
+  await b.start()
+  await linked(a, b)
+
+  const before = a.transport._l2cap.psm
+  t.ok(before !== null, 'listener published while linked')
+
+  await a.suspend()
+  await a.resume()
+
+  await until(() => a.transport._l2cap.psm !== null)
+  const after = a.transport._l2cap.psm
+  t.not(after, before, 'resume republished the listener on a fresh psm')
+
+  await linked(a, b)
+  t.pass('relinked after suspend/resume on the new psm')
+})
+
 test('resume respects stop: a disabled swarm stays off', async (t) => {
   const backend = makeMockBluetooth()
   const a = createSwarm(t, backend)


### PR DESCRIPTION
After suspend/resume the pair never relinks on the l2cap pipe: every dial fails with `CHANNEL_FAILED: L2CAP PSM already connected`. iOS keeps the listener published through suspend and `publish()` no-ops while a psm is set, so the HELLO after resume re-advertises the dead session's psm and the peer's OS refuses every open.

Fix:
- `resume()` cycles the listener so the next HELLO carries a fresh psm. No behavior change on macOS, where suspend already unpublishes.
- The central destroys its stale channel before reopening a peripheral's psm.

Tests 37/37. Verified on-device (iPhone 15 Plus and macOS): 2.2.0 wedges on every background bounce, with this branch the pair relinks in under a second.